### PR TITLE
Update link LICENSE badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,4 @@ Note that tshark is a run-time dependency, and must be in your ```PATH``` for te
 
 ## License
 
-[![License: MIT](https://img.shields.io/github/license/gcla/termshark.svg?color=yellow)](https://opensource.org/licenses/MIT)
-
+[![License: MIT](https://img.shields.io/github/license/gcla/termshark.svg?color=yellow)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ Note that tshark is a run-time dependency, and must be in your ```PATH``` for te
 
 ## License
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/github/license/gcla/termshark.svg?color=yellow)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
- Auto-detect your LICENSE from GitHub
- Change URL to LICENSE instead of the template MIT License (no year and holder)