### PR TITLE
Use more canonical fsnotify import path.

### DIFF
--- a/confwatcher.go
+++ b/confwatcher.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	log "github.com/sirupsen/logrus"
-	fsnotify "gopkg.in/fsnotify.v1"
+	fsnotify "gopkg.in/fsnotify/fsnotify.v1"
 )
 
 //======================================================================

--- a/pcap/loader.go
+++ b/pcap/loader.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gcla/termshark"
 	lru "github.com/hashicorp/golang-lru"
 	log "github.com/sirupsen/logrus"
-	fsnotify "gopkg.in/fsnotify.v1"
+	fsnotify "gopkg.in/fsnotify/fsnotify.v1"
 )
 
 //======================================================================


### PR DESCRIPTION
While there _is_ an alias of https://gopkg.in/fsnotify.v1, if you go there, it only suggests `gopkg.in/fsnotify/fsnotify.v1`, so use that as a more canonical choice.

It's also helpful for Fedora packaging where we don't have that alias provided.