### PR TITLE
add arm64 build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
     - darwin
   goarch:
     - arm
+    - arm64
     - amd64
   ignore:
     - goos: darwin
@@ -22,6 +23,12 @@ builds:
       goarch: arm
     - goos: windows
       goarch: arm
+    - goos: darwin
+      goarch: arm64
+    - goos: freebsd
+      goarch: arm64
+    - goos: windows
+      goarch: arm64
 archives:
 - replacements:
     darwin: macOS

--- a/version.go
+++ b/version.go
@@ -4,7 +4,7 @@
 
 package termshark
 
-var Version string = "v2.1.1"
+var Version string = "v2.1.2"
 
 //======================================================================
 // Local Variables:


### PR DESCRIPTION
This is just a quick hit. I tested it using goreleaser to build on my x86 desktop, then copied the binary to my RPi 4b cluster. 

Termshark came up and worked just fine.

(I'm hoping to help make nicolaka/netshoot multi-arch)