### PR TITLE
docs: add MacPorts install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ tshark has many more features that termshark doesn't expose yet! See [What's Nex
 
 ## Install Packages
 
-Termshark is pre-packaged for the following platforms: [Arch Linux](docs/Packages.md#arch-linux), [Debian (unstable)](docs/Packages.md#debian), [FreeBSD](docs/Packages.md#freebsd), [Homebrew](docs/Packages.md#homebrew), [Kali Linux](docs/Packages.md#kali-linux), [NixOS](docs/Packages.md#nixos), [SnapCraft](docs/Packages.md#snapcraft), [Termux (Android)](docs/Packages.md#termux-android) and [Ubuntu](docs/Packages.md#ubuntu).
+Termshark is pre-packaged for the following platforms: [Arch Linux](docs/Packages.md#arch-linux), [Debian (unstable)](docs/Packages.md#debian), [FreeBSD](docs/Packages.md#freebsd), [Homebrew](docs/Packages.md#homebrew), [MacPorts](docs/Packages.md#macports), [Kali Linux](docs/Packages.md#kali-linux), [NixOS](docs/Packages.md#nixos), [SnapCraft](docs/Packages.md#snapcraft), [Termux (Android)](docs/Packages.md#termux-android) and [Ubuntu](docs/Packages.md#ubuntu).
 
 ## Building
 

--- a/docs/Packages.md
+++ b/docs/Packages.md
@@ -38,6 +38,13 @@ brew update
 brew install termshark
 ```
 
+## MacPorts
+
+```bash
+sudo port selfupdate
+sudo port install termshark
+```
+
 ## Kali Linux
 
 ```bash


### PR DESCRIPTION
Add instructions for installing `termshark` using [MacPorts](https://www.macports.org)