### PR TITLE
Fix various typos

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       run: go build -v ./...
 
-    - name: Install tshark as prequisite for testing
+    - name: Install tshark as prerequisite for testing
       run: sudo sh -c 'export DEBIAN_FRONTEND=noninteractive ; apt -y update && apt -y install tshark'
       
     - name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@ termshark -i eth0 --tty=/dev/pts/5
   see differences between packets more easily.
 - Termshark can now be installed for MacOS from [Homebrew](docs/FAQ.md#homebrew). 
 - Termshark now respects job control signals sent via the shell i.e. SIGTSTP and SIGCONT.
-- Termshark on Windows no longer depends on the Cywgin tail command (and thus a Cygwin installation).
+- Termshark on Windows no longer depends on the Cygwin tail command (and thus a Cygwin installation).
 - The current packet capture source (file, interface, pipe, etc) is displayed in the termshark title bar.
 - Termshark can be configured to eagerly load all pcap PDML data, rather than 1000 packets at a time.
 
@@ -167,7 +167,7 @@ termshark -i eth0 --tty=/dev/pts/5
 
 - Initial release.
 
-[Unreleased]: https://github.com/gcla/termshark/commpare/v2.1.1...HEAD
+[Unreleased]: https://github.com/gcla/termshark/compare/v2.1.1...HEAD
 [1.0.0]: https://github.com/gcla/termshark/releases/tag/v1.0.0
 [2.0.0]: https://github.com/gcla/termshark/releases/tag/v2.0.0
 [2.0.3]: https://github.com/gcla/termshark/releases/tag/v2.0.3

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -349,7 +349,7 @@ To display a table of conversations represented in the current pcap, go to the "
 
 ![convs1](/../gh-pages/images/convs1.png?raw=true)
 
-You can make termshark filter the packets displayed according to the current conversation selected. The "Prepare..." button will set termshark's display filter field, but *not* apply it, letting you futher edit it first. The "Apply..." button will set the display filter and apply it immediately. Navigate to the interesting conversation, then click either "Prepare..." or "Apply..."
+You can make termshark filter the packets displayed according to the current conversation selected. The "Prepare..." button will set termshark's display filter field, but *not* apply it, letting you further edit it first. The "Apply..." button will set the display filter and apply it immediately. Navigate to the interesting conversation, then click either "Prepare..." or "Apply..."
 
 ![convs2](/../gh-pages/images/convs2.png?raw=true)
 

--- a/pkg/shark/wiresharkcfg/parser.go
+++ b/pkg/shark/wiresharkcfg/parser.go
@@ -567,7 +567,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/pkg/shark/wiresharkcfg/parser_test.go
+++ b/pkg/shark/wiresharkcfg/parser_test.go
@@ -143,7 +143,7 @@ func TestArgConv(t *testing.T) {
 #gui.interfaces_remote_display: TRUE
 
 # Hide the given interface types in the startup list.
-# A commma-separated string of interface type values (e.g. 5,9).
+# A comma-separated string of interface type values (e.g. 5,9).
 # 0 = Wired,
 # 1 = AirPCAP,
 # 2 = Pipe,
@@ -163,7 +163,7 @@ func TestArgConv(t *testing.T) {
 # A six-digit hexadecimal RGB color triplet (e.g. fce94f)
 #gui.active_frame.fg: 000000
 
-# Backgound color for an active selected item
+# Background color for an active selected item
 # A six-digit hexadecimal RGB color triplet (e.g. fce94f)
 #gui.active_frame.bg: cbe8ff
 
@@ -176,7 +176,7 @@ func TestArgConv(t *testing.T) {
 # A six-digit hexadecimal RGB color triplet (e.g. fce94f)
 #gui.inactive_frame.fg: 000000
 
-# Backgound color for an inactive selected item
+# Background color for an inactive selected item
 # A six-digit hexadecimal RGB color triplet (e.g. fce94f)
 #gui.inactive_frame.bg: efefef
 
@@ -2291,7 +2291,7 @@ gui.qt.font_name: Liberation Mono,11,-1,5,50,0,0,0,0,0
 
 # Whether the dissector should print items of h245 Info column in reversed order
 # TRUE or FALSE (case-insensitive)
-#h245.prepand: FALSE
+#h245.prepend: FALSE
 
 # Desegment H.501 messages that span more TCP segments
 # TRUE or FALSE (case-insensitive)
@@ -4407,7 +4407,7 @@ gui.qt.font_name: Liberation Mono,11,-1,5,50,0,0,0,0,0
 # TRUE or FALSE (case-insensitive)
 #sip.delay_sdp_changes: FALSE
 
-# Whether the generated call id should be hiddden(not displayed) in the tree or not.
+# Whether the generated call id should be hidden (not displayed) in the tree or not.
 # TRUE or FALSE (case-insensitive)
 #sip.hide_generatd_call_id: FALSE
 

--- a/ui/psmlcolsmodel.go
+++ b/ui/psmlcolsmodel.go
@@ -182,7 +182,7 @@ func (p *psmlColumnsModel) AddRow() {
 	p.Widget = table.New(p)
 }
 
-// cacheHaveCustom keeps track of whther the current model has any custom columns. This
+// cacheHaveCustom keeps track of whether the current model has any custom columns. This
 // is done each time the model is updated. If custom columns are present, the table is
 // displayed with two extra columns.
 func (p *psmlColumnsModel) cacheHaveCustom() {


### PR DESCRIPTION
Found via `codespell  -q 3 -L ba,nd,parms,ser,thann`