### PR TITLE
Add support for loong64

### DIFF
--- a/pkg/system/dup_linux_loong64.go
+++ b/pkg/system/dup_linux_loong64.go
@@ -2,15 +2,10 @@
 // code is governed by the MIT license that can be found in the LICENSE
 // file.
 
-// +build !windows
-// +build !linux !arm64
-// +build !linux !riscv64
-// +build !linux !loong64
-
 package system
 
 import "syscall"
 
 func Dup2(fd int, fd2 int) error {
-	return syscall.Dup2(fd, fd2)
+	return syscall.Dup3(fd, fd2, 0)
 }


### PR DESCRIPTION
To fix the compile failure error on loong64 architecture, link to details:[https://buildd.debian.org/status/fetch.php?pkg=termshark&arch=loong64&ver=2.4.0-1&stamp=1713876936&raw =0](url)